### PR TITLE
Docs: Añadir ejemplo de uso al README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ Los comandos del Makefile funcionarán en Linux y MacOS. En caso de usar Windows
 python3 main.py <filename> <dup>
   filename: **ruta** al fichero que contiene la lista de palabras, una por línea
   dup: **yes|no**, yes para eliminar palabras duplicadas, no para mantener la lista
+
+## Ejemplo de Uso
+
+Para ejecutar el script con un archivo llamado `lista_prueba.txt` y eliminar palabras duplicadas:
+
+python3 main.py lista_prueba.txt yes


### PR DESCRIPTION
Se añade una sección de 'Ejemplo de Uso' al archivo README.md para clarificar cómo ejecutar el script desde la línea de comandos, según sugerencia de la actividad.